### PR TITLE
make it fix x64 lua virtual code really

### DIFF
--- a/include/llimits.h
+++ b/include/llimits.h
@@ -114,7 +114,8 @@ typedef LUA_UACNUMBER l_uacNumber;
 ** type for virtual-machine instructions
 ** must be an unsigned with (at least) 4 bytes (see details in lopcodes.h)
 */
-typedef unsigned long Instruction;
+//typedef unsigned long Instruction;
+typedef size_t Instruction;
 
 
 /* maximum depth for calls (unsigned short) */


### PR DESCRIPTION
but when I had read your codes, there is nothing different from your codes but this:

```
    <ConfigurationType>Application</ConfigurationType>
	    <UseDebugLibraries>true</UseDebugLibraries>
	    <PlatformToolset>v141</PlatformToolset>
	    <CharacterSet>Unicode</CharacterSet>
	    <CharacterSet>MultiByte</CharacterSet>
	  </PropertyGroup>
```


you just change unicode to MutiByte which stands for x64.

but when i test, i got this error:

> LuaDec.exe: virtual machine mismatch in ask.html: size of Instruction is 4 but read 8

I went to this code area:

```
/*
** type for virtual-machine instructions
** must be an unsigned with (at least) 4 bytes (see details in lopcodes.h)
*/
//typedef unsigned long Instruction;
typedef size_t Instruction;
```

then changed `typedef unsigned long Instruction` to `typedef size_t Instruction;`

and it finally works.
